### PR TITLE
Automated Changelog Entry for 0.1.0 on main

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 <!-- <START NEW CHANGELOG ENTRY> -->
 
+## 0.1.0
+
+([Full Changelog](https://github.com/team-monolith-product/jupyterlab-google-analytics/compare/v0.0.3...d866675536a617495a1080f42823f49cb7b57aa1))
+
+### Merged PRs
+
+- Export GA Interface as Token [#6](https://github.com/team-monolith-product/jupyterlab-google-analytics/pull/6) ([@a3626a](https://github.com/a3626a))
+
+### Contributors to this release
+
+([GitHub contributors page for this release](https://github.com/team-monolith-product/jupyterlab-google-analytics/graphs/contributors?from=2022-08-09&to=2022-08-31&type=c))
+
+[@a3626a](https://github.com/search?q=repo%3Ateam-monolith-product%2Fjupyterlab-google-analytics+involves%3Aa3626a+updated%3A2022-08-09..2022-08-31&type=Issues)
+
+<!-- <END NEW CHANGELOG ENTRY> -->
+
 ## 0.0.3
 
 ([Full Changelog](https://github.com/team-monolith-product/jupyterlab-google-analytics/compare/v0.0.2...aa6e12319df55a10bd484d4bcb702dd54e24dc77))
@@ -15,8 +31,6 @@
 ([GitHub contributors page for this release](https://github.com/team-monolith-product/jupyterlab-google-analytics/graphs/contributors?from=2022-08-09&to=2022-08-09&type=c))
 
 [@a3626a](https://github.com/search?q=repo%3Ateam-monolith-product%2Fjupyterlab-google-analytics+involves%3Aa3626a+updated%3A2022-08-09..2022-08-09&type=Issues)
-
-<!-- <END NEW CHANGELOG ENTRY> -->
 
 ## 0.0.2
 


### PR DESCRIPTION
Automated Changelog Entry for 0.1.0 on main

After merging this PR run the "Full Release" Workflow on your fork of `jupyter_releaser` with the following inputs
| Input  | Value |
| ------------- | ------------- |
| Target | team-monolith-product/jupyterlab-google-analytics  |
| Branch  | main  |
| Version Spec | 0.1.0 |
| Since | v0.0.3 |